### PR TITLE
Simplify site to minimal academic-style layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,10 @@
-name: ""
-title: null
+name: "Henrik Hansen"
+title: "Henrik Hansen"
 
+author: "Henrik Hansen"
 email: "hhansen@econ.au.dk"
+
+author_profile: false
 
 remote_theme: just-the-docs/just-the-docs
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,8 +1,9 @@
-<table>
-    <tr>
-        <td><a href=".">Home</a></td>
-        <td><a href="CV">CV</a></td>
-        <td><a href="research_articles">Research</a></td>
-        <td><a href="skateboarding">Skateboarding</a></td>
-    </tr>
-</table>
+<nav class="site-nav-custom" aria-label="Primary">
+  <ul>
+    <li><a href="{{ '/' | relative_url }}" {% if page.url == '/' %}class="active"{% endif %}>Home</a></li>
+    <li><a href="{{ '/research_articles/' | relative_url }}" {% if page.url contains '/research_articles' %}class="active"{% endif %}>Research</a></li>
+    <li><a href="{{ '/CV/' | relative_url }}" {% if page.url contains '/CV' %}class="active"{% endif %}>CV</a></li>
+    <li><a href="{{ '/other/' | relative_url }}" {% if page.url contains '/other' %}class="active"{% endif %}>Interactive graphs</a></li>
+    <li><a href="{{ '/skateboarding/' | relative_url }}" {% if page.url contains '/skateboarding' %}class="active"{% endif %}>Skateboarding</a></li>
+  </ul>
+</nav>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,26 +1,58 @@
 .side-bar {
-  width: 10%;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  border-right: 0;
+  border-bottom: 1px solid #e6e6e6;
+  padding: 0.6rem 1.5rem;
 }
 
-/* Responsive: on small screens make the sidebar full width and stack links */
-@media (max-width: 768px) {
-  .side-bar {
-    width: 100% !important;
-    float: none !important;
-    display: block !important;
-  }
+.main {
+  margin-left: 0;
+  max-width: 68rem;
+}
 
-  /* The navigation include currently uses a table. Make the table and its cells
-     behave like block elements on small screens so links don't get squeezed. */
-  .side-bar table,
-  .side-bar table tr,
-  .side-bar table td {
+.site-header {
+  margin: 0;
+  padding: 0;
+}
+
+.site-title {
+  display: none;
+}
+
+.site-nav-custom ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.site-nav-custom a {
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.site-nav-custom a.active {
+  font-weight: 700;
+  border-bottom: 2px solid currentColor;
+}
+
+.profile-photo {
+  float: right;
+  margin-left: 1.5rem;
+  margin-bottom: 1rem;
+  width: 220px;
+  border-radius: 4px;
+}
+
+@media (max-width: 900px) {
+  .profile-photo {
+    float: none;
     display: block;
-    width: 100%;
-  }
-
-  .side-bar table td a {
-    display: inline-block;
-    padding: 0.5rem 1rem;
+    margin: 0 0 1rem;
+    width: 180px;
   }
 }

--- a/index.md
+++ b/index.md
@@ -4,9 +4,7 @@ nav_order: 1
 
 # Home
 
-<div style="float: right; margin-left: 32px;">
-  <img src="assets/Untitled.png" alt="Profile" width="200">
-</div>
+<img class="profile-photo" src="assets/Untitled.png" alt="Profile photo of Henrik Hansen">
 
 **Henrik Hansen**  
 PhD student *(2022-2026)*


### PR DESCRIPTION
### Motivation
- Reduce repository bloat and keep only the essential academic-style layout (top tab navigation and a profile photo) while preserving existing page content and links.
- Remove local-preview scaffolding that was added earlier so the site stays lean and minimal.

### Description
- Replaced the table-based navigation with a semantic top tab bar in `_includes/navigation.html` using an unordered list and Liquid active-tab highlighting (`class="active"`).
- Reduced custom styling in `_sass/custom/custom.scss` to only the rules required for the horizontal top tabs, page width adjustments, and the floating/responsive profile photo (`.profile-photo`).
- Simplified the home page `index.md` to plain Markdown with a single floating profile image (`assets/Untitled.png`) and the original contact/content lines.
- Removed the added preview scaffolding by deleting the `Gemfile` and removing the `plugins:` block for `jekyll-remote-theme` from `_config.yml`, and added basic site metadata (`name`, `title`, `author`) to `_config.yml`.

### Testing
- Ran file inspections with `nl -ba` / `sed` on `index.md`, `_sass/custom/custom.scss`, `_includes/navigation.html`, and `_config.yml` to verify the edits, and these checks succeeded.
- Ran `git status --short` to confirm the working tree state, and the repository reflected the intended changes.
- Attempted an automated Playwright script to capture `http://127.0.0.1:4000`, which failed with `ERR_EMPTY_RESPONSE` because no local Jekyll server was running in this environment (expected limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8039b8b48328a920e4b4ad492239)